### PR TITLE
update cloudant name

### DIFF
--- a/cloudant-and-cis.md
+++ b/cloudant-and-cis.md
@@ -47,4 +47,4 @@ These instructions assume you have already added a domain to CIS as outlined in 
 * Select the Rule Behavior setting `Host Header Override`.
 * Set as the Cloudant database hostname, for example, `111-222-333-444-555-test.cloudant.com`.
 
-For more information on Cloudant, see the [Coudant documentation](/docs/services/Cloudant?topic=cloudant-getting-started).
+For more information on Cloudant, see the [Cloudant documentation](/docs/services/Cloudant?topic=cloudant-getting-started-with-cloudant).


### PR DESCRIPTION
https://cloud.ibm.com/docs/services/Cloudant?topic=cloudant-getting-started-with-cloudant the old url is broken.